### PR TITLE
create of prototype_table

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,3 +48,4 @@ end
 gem 'haml-rails'
 gem 'bootstrap-sass'
 gem 'devise'
+gem 'carrierwave'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,12 @@ GEM
       sass (>= 3.3.4)
     builder (3.2.2)
     byebug (9.0.5)
+    carrierwave (0.11.2)
+      activemodel (>= 3.2.0)
+      activesupport (>= 3.2.0)
+      json (>= 1.7)
+      mime-types (>= 1.16)
+      mimemagic (>= 0.3.0)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.1.x)
@@ -95,6 +101,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
+    mimemagic (0.3.2)
     mini_portile2 (2.1.0)
     minitest (5.9.0)
     multi_json (1.12.1)
@@ -181,6 +188,7 @@ PLATFORMS
 DEPENDENCIES
   bootstrap-sass
   byebug
+  carrierwave
   coffee-rails (~> 4.1.0)
   devise
   haml-rails

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -1,0 +1,2 @@
+class Prototype < ActiveRecord::Base
+end

--- a/db/migrate/20160806024427_create_prototypes.rb
+++ b/db/migrate/20160806024427_create_prototypes.rb
@@ -1,0 +1,8 @@
+class CreatePrototypes < ActiveRecord::Migration
+  def change
+    create_table :prototypes do |t|
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160806024427_create_prototypes.rb
+++ b/db/migrate/20160806024427_create_prototypes.rb
@@ -1,8 +1,11 @@
 class CreatePrototypes < ActiveRecord::Migration
   def change
     create_table :prototypes do |t|
-
-      t.timestamps null: false
+      t.string      :title
+      t.string      :catchcopy
+      t.text        :concept
+      t.references  :user, index: true, foreign_key: true
+      t.timestamps
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160731114149) do
+ActiveRecord::Schema.define(version: 20160806024427) do
+
+  create_table "prototypes", force: :cascade do |t|
+    t.string   "title",      limit: 255
+    t.string   "catchcopy",  limit: 255
+    t.text     "concept",    limit: 65535
+    t.integer  "user_id",    limit: 4
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "prototypes", ["user_id"], name: "index_prototypes_on_user_id", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  limit: 255,   default: "", null: false
@@ -36,4 +47,5 @@ ActiveRecord::Schema.define(version: 20160731114149) do
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
+  add_foreign_key "prototypes", "users"
 end


### PR DESCRIPTION
## WHAT

gemのcarrierwaveの導入
Prototypeモデル、テーブルの作成
## WHY

プロトタイプ投稿を行う際のモデルとテーブルを作成するため
